### PR TITLE
Map each icon to multiple types of posts and events

### DIFF
--- a/_src/_includes/icon.html
+++ b/_src/_includes/icon.html
@@ -1,0 +1,15 @@
+{% if 'link' contains include.icon_type %}
+  <i class="jf-i-link"></i>
+{% elsif 'file blog post writing essay' contains include.icon_type %}
+  <i class="jf-i-file"></i>
+{% elsif 'plane travel trip' contains include.icon_type %}
+  <i class="jf-i-plane"></i>
+{% elsif 'comment' contains include.icon_type %}
+  <i class="jf-i-comment"></i>
+{% elsif 'professor talk speaking' contains include.icon_type %}
+  <i class="jf-i-professor"></i>
+{% elsif 'videocamera video film' contains include.icon_type %}
+  <i class="jf-i-videocamera"></i>
+{% else %}
+  Please see _src/_includes/icon.html to see the correct icon types.
+{% endif %}

--- a/_src/_includes/list-item-meta.html
+++ b/_src/_includes/list-item-meta.html
@@ -1,4 +1,4 @@
 <span class="muted">
-  <i class="jf-i-{% if include.icon_type %}{{include.icon_type}}{% else %}file{% endif %}"></i> &nbsp;
+  {% include icon.html icon_type=include.icon_type %} &nbsp;
   {% include short-date.html date=include.date %}
 </span>

--- a/_src/_includes/post-list-item.html
+++ b/_src/_includes/post-list-item.html
@@ -3,7 +3,7 @@
     <div class="media-object-figure mr1 txt--right">
       <h3 class="list-item-title">
         <a href="{{include.post.url | prepend: site.baseurl}}" title="{{include.post.title}}">
-          <i class="jf-i-{% if include.post.icon_type %}{{include.post.icon_type}}{% else %}file{% endif %}"></i>
+          {% include icon.html icon_type=include.post.icon_type %}
         </a>
       </h3>
       <div class="muted--2x">

--- a/_src/_posts/2014-11-09-see-everything-in-action.markdown
+++ b/_src/_posts/2014-11-09-see-everything-in-action.markdown
@@ -3,6 +3,7 @@ layout:        post
 title:         See Everything in Action with a Really Long Post Title
 date:          2014-11-09 12:36:06
 nav_highlight: blog
+icon_type:     post
 description:   See what the different elements looks like. Your markdown has never looked better. I promise.
 tags:          jekyll pixyll
 ---


### PR DESCRIPTION
This breaks out the icon into it's own include where a string of enumerated
post types is checked to see whether it contains the icon type. If no match
is made, a help message is instead displayed.
